### PR TITLE
Hotfix: Change variable name

### DIFF
--- a/git/index.js
+++ b/git/index.js
@@ -60,7 +60,7 @@ if (args.branch || args.b) {
 }
 
 if (args.repository || args.r) {
-  branch = args.repository || args.r;
+  repository = args.repository || args.r;
 }
 
 if (args.tech || args.t) {


### PR DESCRIPTION
## Summary

Change variable name from `branch` to `repository`