### PR TITLE
git metrics are now calculated with a separate package

### DIFF
--- a/git/index.js
+++ b/git/index.js
@@ -12,11 +12,9 @@ let projectName = '';
 let metricsUrl = '';
 let apiKey = '';
 let organization = 'wolox';
-let gitProvider = '';
+let gitProvider = 'github';
 
 const args = parseArgs(process.argv);
-
-console.log(args);
 
 if (args.branch || args.b) {
   branch = args.branch || args.b;

--- a/git/index.js
+++ b/git/index.js
@@ -48,7 +48,9 @@ if (args.gitProvider || args.g) {
   gitProvider = args.gitProvider || args.g;
 }
 
-runGitChecks(gitProvider, process.env.OAUTH_TOKEN)(repository, organization).then(metrics => {
+const authToken = gitProvider === 'github' ? process.env.OAUTH_TOKEN : process.env.GITLAB_OAUTH_TOKEN;
+
+runGitChecks(gitProvider, authToken)(repository, organization).then(metrics => {
   const validMetrics = metrics.filter((metric) => !!metric.value);
   const builtMetrics = buildMetrics({ metrics: validMetrics, repository, env: branch, tech, projectName })
   console.log('Saving the following metrics:', builtMetrics);

--- a/git/package-lock.json
+++ b/git/package-lock.json
@@ -1,0 +1,1910 @@
+{
+  "name": "git-metrics",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@wolox/git-metrics": {
+      "version": "0.1.1",
+      "requires": {
+        "axios": "^0.21.1"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.12.11",
+          "bundled": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.12.11",
+          "bundled": true
+        },
+        "@babel/highlight": {
+          "version": "7.13.10",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            }
+          }
+        },
+        "@eslint/eslintrc": {
+          "version": "0.4.0",
+          "bundled": true,
+          "requires": {
+            "ajv": "^6.12.4",
+            "debug": "^4.1.1",
+            "espree": "^7.3.0",
+            "globals": "^12.1.0",
+            "ignore": "^4.0.6",
+            "import-fresh": "^3.2.1",
+            "js-yaml": "^3.13.1",
+            "minimatch": "^3.0.4",
+            "strip-json-comments": "^3.1.1"
+          }
+        },
+        "@types/eslint-visitor-keys": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "@types/json-schema": {
+          "version": "7.0.7",
+          "bundled": true
+        },
+        "@types/json5": {
+          "version": "0.0.29",
+          "bundled": true
+        },
+        "@typescript-eslint/experimental-utils": {
+          "version": "3.10.1",
+          "bundled": true,
+          "requires": {
+            "@types/json-schema": "^7.0.3",
+            "@typescript-eslint/types": "3.10.1",
+            "@typescript-eslint/typescript-estree": "3.10.1",
+            "eslint-scope": "^5.0.0",
+            "eslint-utils": "^2.0.0"
+          }
+        },
+        "@typescript-eslint/parser": {
+          "version": "3.10.1",
+          "bundled": true,
+          "requires": {
+            "@types/eslint-visitor-keys": "^1.0.0",
+            "@typescript-eslint/experimental-utils": "3.10.1",
+            "@typescript-eslint/types": "3.10.1",
+            "@typescript-eslint/typescript-estree": "3.10.1",
+            "eslint-visitor-keys": "^1.1.0"
+          },
+          "dependencies": {
+            "eslint-visitor-keys": {
+              "version": "1.3.0",
+              "bundled": true
+            }
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "3.10.1",
+          "bundled": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "3.10.1",
+          "bundled": true,
+          "requires": {
+            "@typescript-eslint/types": "3.10.1",
+            "@typescript-eslint/visitor-keys": "3.10.1",
+            "debug": "^4.1.1",
+            "glob": "^7.1.6",
+            "is-glob": "^4.0.1",
+            "lodash": "^4.17.15",
+            "semver": "^7.3.2",
+            "tsutils": "^3.17.1"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "3.10.1",
+          "bundled": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          },
+          "dependencies": {
+            "eslint-visitor-keys": {
+              "version": "1.3.0",
+              "bundled": true
+            }
+          }
+        },
+        "@wolox/eslint-config": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "acorn": {
+          "version": "7.4.1",
+          "bundled": true
+        },
+        "acorn-jsx": {
+          "version": "5.3.1",
+          "bundled": true
+        },
+        "ajv": {
+          "version": "6.12.6",
+          "bundled": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-colors": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "bundled": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "bundled": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "argparse": {
+          "version": "1.0.10",
+          "bundled": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "array-includes": {
+          "version": "3.1.3",
+          "bundled": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.18.0-next.2",
+            "get-intrinsic": "^1.1.1",
+            "is-string": "^1.0.5"
+          }
+        },
+        "array.prototype.flat": {
+          "version": "1.2.4",
+          "bundled": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.18.0-next.1"
+          }
+        },
+        "astral-regex": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "axios": {
+          "version": "0.21.1",
+          "bundled": true,
+          "requires": {
+            "follow-redirects": "^1.10.0"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "call-bind": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2"
+          }
+        },
+        "callsites": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "4.3.0",
+              "bundled": true,
+              "requires": {
+                "color-convert": "^2.0.1"
+              }
+            },
+            "color-convert": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "color-name": "~1.1.4"
+              }
+            },
+            "color-name": {
+              "version": "1.1.4",
+              "bundled": true
+            },
+            "has-flag": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "bundled": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "common-tags": {
+          "version": "1.8.0",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "contains-path": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "bundled": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "debug": {
+          "version": "4.3.1",
+          "bundled": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "define-properties": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "dlv": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "doctrine": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "bundled": true
+        },
+        "enquirer": {
+          "version": "2.3.6",
+          "bundled": true,
+          "requires": {
+            "ansi-colors": "^4.1.1"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.2",
+          "bundled": true,
+          "requires": {
+            "is-arrayish": "^0.2.1"
+          }
+        },
+        "es-abstract": {
+          "version": "1.18.0",
+          "bundled": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.2",
+            "is-callable": "^1.2.3",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.2",
+            "is-string": "^1.0.5",
+            "object-inspect": "^1.9.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.0"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "eslint": {
+          "version": "7.21.0",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "7.12.11",
+            "@eslint/eslintrc": "^0.4.0",
+            "ajv": "^6.10.0",
+            "chalk": "^4.0.0",
+            "cross-spawn": "^7.0.2",
+            "debug": "^4.0.1",
+            "doctrine": "^3.0.0",
+            "enquirer": "^2.3.5",
+            "eslint-scope": "^5.1.1",
+            "eslint-utils": "^2.1.0",
+            "eslint-visitor-keys": "^2.0.0",
+            "espree": "^7.3.1",
+            "esquery": "^1.4.0",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^6.0.1",
+            "functional-red-black-tree": "^1.0.1",
+            "glob-parent": "^5.0.0",
+            "globals": "^12.1.0",
+            "ignore": "^4.0.6",
+            "import-fresh": "^3.0.0",
+            "imurmurhash": "^0.1.4",
+            "is-glob": "^4.0.0",
+            "js-yaml": "^3.13.1",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.4.1",
+            "lodash": "^4.17.20",
+            "minimatch": "^3.0.4",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.9.1",
+            "progress": "^2.0.0",
+            "regexpp": "^3.1.0",
+            "semver": "^7.2.1",
+            "strip-ansi": "^6.0.0",
+            "strip-json-comments": "^3.1.0",
+            "table": "^6.0.4",
+            "text-table": "^0.2.0",
+            "v8-compile-cache": "^2.0.3"
+          }
+        },
+        "eslint-import-resolver-node": {
+          "version": "0.3.4",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.6.9",
+            "resolve": "^1.13.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "eslint-module-utils": {
+          "version": "2.6.0",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.6.9",
+            "pkg-dir": "^2.0.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "eslint-plugin-import": {
+          "version": "2.22.1",
+          "bundled": true,
+          "requires": {
+            "array-includes": "^3.1.1",
+            "array.prototype.flat": "^1.2.3",
+            "contains-path": "^0.1.0",
+            "debug": "^2.6.9",
+            "doctrine": "1.5.0",
+            "eslint-import-resolver-node": "^0.3.4",
+            "eslint-module-utils": "^2.6.0",
+            "has": "^1.0.3",
+            "minimatch": "^3.0.4",
+            "object.values": "^1.1.1",
+            "read-pkg-up": "^2.0.0",
+            "resolve": "^1.17.0",
+            "tsconfig-paths": "^3.9.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "doctrine": {
+              "version": "1.5.0",
+              "bundled": true,
+              "requires": {
+                "esutils": "^2.0.2",
+                "isarray": "^1.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "eslint-plugin-prettier": {
+          "version": "3.3.1",
+          "bundled": true,
+          "requires": {
+            "prettier-linter-helpers": "^1.0.0"
+          }
+        },
+        "eslint-scope": {
+          "version": "5.1.1",
+          "bundled": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "eslint-utils": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          },
+          "dependencies": {
+            "eslint-visitor-keys": {
+              "version": "1.3.0",
+              "bundled": true
+            }
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "espree": {
+          "version": "7.3.1",
+          "bundled": true,
+          "requires": {
+            "acorn": "^7.4.0",
+            "acorn-jsx": "^5.3.1",
+            "eslint-visitor-keys": "^1.3.0"
+          },
+          "dependencies": {
+            "eslint-visitor-keys": {
+              "version": "1.3.0",
+              "bundled": true
+            }
+          }
+        },
+        "esprima": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "esquery": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "estraverse": "^5.1.0"
+          },
+          "dependencies": {
+            "estraverse": {
+              "version": "5.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "esrecurse": {
+          "version": "4.3.0",
+          "bundled": true,
+          "requires": {
+            "estraverse": "^5.2.0"
+          },
+          "dependencies": {
+            "estraverse": {
+              "version": "5.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "estraverse": {
+          "version": "4.3.0",
+          "bundled": true
+        },
+        "esutils": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "bundled": true
+        },
+        "fast-diff": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "file-entry-cache": {
+          "version": "6.0.1",
+          "bundled": true,
+          "requires": {
+            "flat-cache": "^3.0.4"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "flat-cache": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "flatted": "^3.1.0",
+            "rimraf": "^3.0.2"
+          }
+        },
+        "flatted": {
+          "version": "3.1.1",
+          "bundled": true
+        },
+        "follow-redirects": {
+          "version": "1.13.3",
+          "bundled": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "functional-red-black-tree": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "glob": {
+          "version": "7.1.6",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.2",
+          "bundled": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "globals": {
+          "version": "12.4.0",
+          "bundled": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.6",
+          "bundled": true
+        },
+        "has": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "has-bigints": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "has-symbols": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "hosted-git-info": {
+          "version": "2.8.8",
+          "bundled": true
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "bundled": true
+        },
+        "import-fresh": {
+          "version": "3.3.0",
+          "bundled": true,
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "indent-string": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "bundled": true
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "is-bigint": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-boolean-object": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "call-bind": "^1.0.0"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.3",
+          "bundled": true
+        },
+        "is-core-module": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "has": "^1.0.3"
+          }
+        },
+        "is-date-object": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "is-glob": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-negative-zero": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "is-number-object": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "is-regex": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "is-string": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "is-symbol": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "bundled": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "bundled": true
+        },
+        "json-stable-stringify-without-jsonify": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "json5": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "levn": {
+          "version": "0.4.1",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "^1.2.1",
+            "type-check": "~0.4.0"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "bundled": true
+        },
+        "lodash.merge": {
+          "version": "4.6.2",
+          "bundled": true
+        },
+        "loglevel": {
+          "version": "1.7.1",
+          "bundled": true
+        },
+        "loglevel-colored-level-prefix": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "^1.1.3",
+            "loglevel": "^1.4.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "bundled": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "bundled": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "natural-compare": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "bundled": true
+            }
+          }
+        },
+        "object-inspect": {
+          "version": "1.9.0",
+          "bundled": true
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "object.values": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.18.0-next.2",
+            "has": "^1.0.3"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "optionator": {
+          "version": "0.9.1",
+          "bundled": true,
+          "requires": {
+            "deep-is": "^0.1.3",
+            "fast-levenshtein": "^2.0.6",
+            "levn": "^0.4.1",
+            "prelude-ls": "^1.2.1",
+            "type-check": "^0.4.0",
+            "word-wrap": "^1.2.3"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "parent-module": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "callsites": "^3.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "bundled": true
+        },
+        "path-parse": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        },
+        "prelude-ls": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "prettier": {
+          "version": "2.2.1",
+          "bundled": true
+        },
+        "prettier-eslint": {
+          "version": "12.0.0",
+          "bundled": true,
+          "requires": {
+            "@typescript-eslint/parser": "^3.0.0",
+            "common-tags": "^1.4.0",
+            "dlv": "^1.1.0",
+            "eslint": "^7.9.0",
+            "indent-string": "^4.0.0",
+            "lodash.merge": "^4.6.0",
+            "loglevel-colored-level-prefix": "^1.0.0",
+            "prettier": "^2.0.0",
+            "pretty-format": "^23.0.1",
+            "require-relative": "^0.8.7",
+            "typescript": "^3.9.3",
+            "vue-eslint-parser": "~7.1.0"
+          }
+        },
+        "prettier-linter-helpers": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "fast-diff": "^1.1.2"
+          }
+        },
+        "pretty-format": {
+          "version": "23.6.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^3.0.0",
+            "ansi-styles": "^3.2.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "progress": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          }
+        },
+        "regexpp": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "require-from-string": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "require-relative": {
+          "version": "0.8.7",
+          "bundled": true
+        },
+        "resolve": {
+          "version": "1.20.0",
+          "bundled": true,
+          "requires": {
+            "is-core-module": "^2.2.0",
+            "path-parse": "^1.0.6"
+          }
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "7.3.4",
+          "bundled": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "slice-ansi": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "4.3.0",
+              "bundled": true,
+              "requires": {
+                "color-convert": "^2.0.1"
+              }
+            },
+            "color-convert": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "color-name": "~1.1.4"
+              }
+            },
+            "color-name": {
+              "version": "1.1.4",
+              "bundled": true
+            }
+          }
+        },
+        "spdx-correct": {
+          "version": "3.1.1",
+          "bundled": true,
+          "requires": {
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.7",
+          "bundled": true
+        },
+        "sprintf-js": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "4.2.2",
+          "bundled": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "strip-json-comments": {
+          "version": "3.1.1",
+          "bundled": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "bundled": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "table": {
+          "version": "6.0.7",
+          "bundled": true,
+          "requires": {
+            "ajv": "^7.0.2",
+            "lodash": "^4.17.20",
+            "slice-ansi": "^4.0.0",
+            "string-width": "^4.2.0"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "7.2.1",
+              "bundled": true,
+              "requires": {
+                "fast-deep-equal": "^3.1.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
+                "uri-js": "^4.2.2"
+              }
+            },
+            "json-schema-traverse": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "tsconfig-paths": {
+          "version": "3.9.0",
+          "bundled": true,
+          "requires": {
+            "@types/json5": "^0.0.29",
+            "json5": "^1.0.1",
+            "minimist": "^1.2.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "bundled": true
+        },
+        "tsutils": {
+          "version": "3.21.0",
+          "bundled": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        },
+        "type-check": {
+          "version": "0.4.0",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "^1.2.1"
+          }
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "bundled": true
+        },
+        "typescript": {
+          "version": "3.9.9",
+          "bundled": true
+        },
+        "unbox-primitive": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has-bigints": "^1.0.0",
+            "has-symbols": "^1.0.0",
+            "which-boxed-primitive": "^1.0.1"
+          }
+        },
+        "uri-js": {
+          "version": "4.4.1",
+          "bundled": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "v8-compile-cache": {
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
+          }
+        },
+        "vue-eslint-parser": {
+          "version": "7.1.1",
+          "bundled": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "eslint-scope": "^5.0.0",
+            "eslint-visitor-keys": "^1.1.0",
+            "espree": "^6.2.1",
+            "esquery": "^1.0.1",
+            "lodash": "^4.17.15"
+          },
+          "dependencies": {
+            "eslint-visitor-keys": {
+              "version": "1.3.0",
+              "bundled": true
+            },
+            "espree": {
+              "version": "6.2.1",
+              "bundled": true,
+              "requires": {
+                "acorn": "^7.1.1",
+                "acorn-jsx": "^5.2.0",
+                "eslint-visitor-keys": "^1.1.0"
+              }
+            }
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "which-boxed-primitive": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "is-bigint": "^1.0.1",
+            "is-boolean-object": "^1.1.0",
+            "is-number-object": "^1.0.4",
+            "is-string": "^1.0.5",
+            "is-symbol": "^1.0.3"
+          }
+        },
+        "word-wrap": {
+          "version": "1.2.3",
+          "bundled": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "bundled": true
+        }
+      }
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+    },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cross-fetch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.2.tgz",
+      "integrity": "sha1-pH/09/xxLauo9qaVoRyUhEDUVyM=",
+      "requires": {
+        "node-fetch": "2.1.2",
+        "whatwg-fetch": "2.0.4"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "follow-redirects": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "graphql": {
+      "version": "14.7.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.7.0.tgz",
+      "integrity": "sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==",
+      "requires": {
+        "iterall": "^1.2.2"
+      }
+    },
+    "graphql-request": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-1.8.2.tgz",
+      "integrity": "sha512-dDX2M+VMsxXFCmUX0Vo0TopIZIX4ggzOtiCsThgtrKR4niiaagsGTDIHj3fsOMFETpa064vzovI+4YV4QnMbcg==",
+      "requires": {
+        "cross-fetch": "2.2.2"
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "iterall": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
+    },
+    "mime-db": {
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
+      "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ=="
+    },
+    "mime-types": {
+      "version": "2.1.29",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
+      "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
+      "requires": {
+        "mime-db": "1.46.0"
+      }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "node-fetch": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+      "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      }
+    },
+    "request-promise": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.6.tgz",
+      "integrity": "sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==",
+      "requires": {
+        "bluebird": "^3.5.0",
+        "request-promise-core": "1.1.4",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+      "requires": {
+        "lodash": "^4.17.19"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+    },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "whatwg-fetch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+    }
+  }
+}

--- a/git/package.json
+++ b/git/package.json
@@ -9,10 +9,14 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "axios": "^0.21.1",
+    "dotenv": "^8.2.0",
     "graphql": "^14.6.0",
     "graphql-request": "^1.8.2",
+    "lodash.flattendeep": "^4.4.0",
     "minimist": "^1.2.0",
     "request": "^2.88.0",
-    "request-promise": "^4.2.5"
+    "request-promise": "^4.2.5",
+    "@wolox/git-metrics": "^0.1.1"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
## Summary

Now git metrics al calculated with [@wolox/git-metrics](https://github.com/Wolox/metrics) which basically replaces node-github-stats.
The main change to the script is the addition of gitProvider, since it now supports gitlab in addition to github.
